### PR TITLE
Fix autoUpgrade channel, revert stateVersion to 22.11 as you are not meant to change it and changes to make the file easier to work with

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -60,6 +60,7 @@
 
   # Enable the X11 windowing system.
   services.xserver.enable = true;
+  # This installs dwm so there's no need to have it in environment.systemPackages.
   services.xserver.windowManager.dwm.enable = true;
   services.xserver.layout = "us";
   services.xserver.displayManager = {
@@ -71,6 +72,9 @@
     setupCommands = ''
       ${pkgs.xorg.xrandr}/bin/xrandr --output DP-1 --off --output DP-2 --off --output DP-3 --off --output HDMI-1 --mode 1920x1080 --pos 0x0 --rotate normal
     '';
+
+    # Uncomment this to install bspwm - removing from environment.systemPackages.
+    # services.xserver.windowManager.bspwm.enable = true;
   };
 
   services.picom.enable = true;
@@ -80,7 +84,6 @@
 
   # Define a user account. Don't forget to set a password with ‘passwd’.
   users.users.titus = {
-    isNormalUser = true;
     isNormalUser = true;
     description = "Titus";
     extraGroups = [    
@@ -103,7 +106,6 @@
   # $ nix search wget
   environment.systemPackages = with pkgs; [
     autojump
-    bspwm
     cargo
     celluloid
     chatterino2
@@ -111,12 +113,10 @@
     davinci-resolve
     dmenu
     dunst
-    dwm
     elinks
     eww
     feh
     flameshot
-    flatpak
     floorp
     fontconfig
     freetype
@@ -136,8 +136,6 @@
     mangohud
     neofetch
     neovim
-    neovim
-    nerdfonts
     nfs-utils
     ninja
     nodejs
@@ -150,13 +148,11 @@
     protonup-ng
     python3Full
     python.pkgs.pip
-    qemu
     ripgrep
     rofi
     st
     starship
     stdenv
-    steam
     steam-run
     sxhkd
     synergy
@@ -171,7 +167,6 @@
     w3m
     wget
     xclip
-    xdg-desktop-portal-gtk
     xfce.thunar
     xorg.libX11
     xorg.libX11.dev
@@ -197,6 +192,7 @@
 
   ## Gaming
   programs.steam = {
+    # This installs Steam, so there's no need to have it in environment.systemPackages.
     enable = true;
     remotePlay.openFirewall = true; # Open ports in the firewall for Steam Remote Play
     dedicatedServer.openFirewall = true; # Open ports in the firewall for Source Dedicated Server
@@ -204,15 +200,18 @@
 
 
   # List services that you want to enable:
+
+  # This installs QEMU, so there's no need to have it in environment.systemPackages
   virtualisation.libvirtd.enable = true;
-  # enable flatpak support
+
+  # Enable flatpak support. This already installs Flatpak so there's no need to have it in environment.systemPackages.
   services.flatpak.enable = true;
   services.dbus.enable = true;
   xdg.portal = {
     enable = true;
     # wlr.enable = true;
-    # gtk portal needed to make gtk apps happy
-    extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
+    # gtk portal needed to make gtk apps happy. Since it's declared here, there's no need to have it in environment.systemPackages.
+    extraPortals = with pkgs; [xdg-desktop-portal-gtk];
   };
   security.polkit.enable = true;
   systemd = {
@@ -250,6 +249,7 @@
       source-han-sans
       source-han-sans-japanese
       source-han-serif-japanese
+      # Nerdfonts is declared here, so there's no need to have it in environment.systemPackages.
       (nerdfonts.override { fonts = [ "Meslo" ]; })
     ];
     fontconfig = {

--- a/configuration.nix
+++ b/configuration.nix
@@ -240,8 +240,8 @@
   networking.firewall.enable = false;
   networking.enableIPv6 = false;
 
-  fonts = {                                                  #This is depricated new sytax will
-    fonts = with pkgs; [                                   #be enforced in the next realease
+  fonts = {                                                   # This is the new syntax.
+    packages = with pkgs; [                                   # Changing it so you don't have to later on.
       noto-fonts
       noto-fonts-cjk
       noto-fonts-emoji
@@ -268,7 +268,7 @@
   system.copySystemConfiguration = true;
   system.autoUpgrade.enable = true;
   system.autoUpgrade.allowReboot = true;
-  system.autoUpgrade.channel = "https://channels.nixos.org/nixos-24.05";
+  system.autoUpgrade.channel = "https://channels.nixos.org/nixos-23.11";
 
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
@@ -276,5 +276,5 @@
   # this value at the release version of the first install of this system.
   # Before changing this value read the documentation for this option
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
-  system.stateVersion = "23.11"; # Did you read the comment?
+  system.stateVersion = "22.11"; # Did you read the comment?
 }

--- a/configuration.nix
+++ b/configuration.nix
@@ -14,27 +14,27 @@
     };
   };
   nixpkgs.config.permittedInsecurePackages = [
-                "openssl-1.1.1v"
-		"python-2.7.18.6"
-              ];
-hardware.opengl.driSupport32Bit = true;
-hardware.pulseaudio.support32Bit = true;
-nixpkgs.config.allowUnfreePredicate = (pkg: builtins.elem (builtins.parseDrvName pkg.name).name [ "steam" ]);
-nix.settings = {
+    "openssl-1.1.1v"
+    "python-2.7.18.6"
+  ];
+  hardware.opengl.driSupport32Bit = true;
+  hardware.pulseaudio.support32Bit = true;
+  nixpkgs.config.allowUnfreePredicate = (pkg: builtins.elem (builtins.parseDrvName pkg.name).name [ "steam" ]);
+  nix.settings = {
     substituters = ["https://nix-gaming.cachix.org"];
     trusted-public-keys = ["nix-gaming.cachix.org-1:nbjlureqMbRAxR1gJ/f3hxemL9svXaZF/Ees8vCUUs4="];
   };
 
-  imports =
-    [ # Include the results of the hardware scan.
-      ./hardware-configuration.nix
-    ];
+  imports = [
+    # Include the results of the hardware scan.
+    ./hardware-configuration.nix
+  ];
 
   # Use the systemd-boot EFI boot loader.
-#  boot.loader.systemd-boot.enable = true;
-#  boot.loader.efi.canTouchEfiVariables = true;
+  # boot.loader.systemd-boot.enable = true;
+  # boot.loader.efi.canTouchEfiVariables = true;
 
- boot = {
+  boot = {
     tmp.cleanOnBoot = true;
     supportedFilesystems = [ "ntfs" ];
     loader = {
@@ -62,27 +62,26 @@ nix.settings = {
   services.xserver.enable = true;
   services.xserver.windowManager.dwm.enable = true;
   services.xserver.layout = "us";
-
   services.xserver.displayManager = {
-	lightdm.enable = true;
-  	autoLogin = {
-		enable = true;
-		user = "titus";
-	};
+    lightdm.enable = true;
+    autoLogin = {
+      enable = true;
+      user = "titus";
+    };
+    setupCommands = ''
+      ${pkgs.xorg.xrandr}/bin/xrandr --output DP-1 --off --output DP-2 --off --output DP-3 --off --output HDMI-1 --mode 1920x1080 --pos 0x0 --rotate normal
+    '';
   };
-services.xserver.displayManager.setupCommands = ''
-    ${pkgs.xorg.xrandr}/bin/xrandr --output DP-1 --off --output DP-2 --off --output DP-3 --off --output HDMI-1 --mode 1920x1080 --pos 0x0 --rotate normal
-'';
 
- services.picom.enable = true;
+  services.picom.enable = true;
   # Enable sound.
   sound.enable = true;
   hardware.pulseaudio.enable = true;
 
   # Define a user account. Don't forget to set a password with ‘passwd’.
   users.users.titus = {
-     isNormalUser = true;
-     isNormalUser = true;
+    isNormalUser = true;
+    isNormalUser = true;
     description = "Titus";
     extraGroups = [    
       "flatpak"
@@ -102,106 +101,106 @@ services.xserver.displayManager.setupCommands = ''
 
   # List packages installed in system profile. To search, run:
   # $ nix search wget
-   environment.systemPackages = with pkgs; [
-        vim
-	wget
-	w3m
-	dmenu
-        neofetch
-	neovim
-	autojump
-	starship
-	floorp
-	bspwm
-	cargo
-	celluloid
-	chatterino2
-  	clang-tools_9
-	davinci-resolve
-	dwm
-	dunst
-	elinks
-	eww
-	feh
-	flameshot
-	flatpak
-  	fontconfig
-  	freetype
-	gcc
-	gh
-	gimp
-	git
-	github-desktop
-	gnugrep
-	gnumake
-	gparted
-	hugo
-	kitty
-	libverto
-  	luarocks
-	lutris
-	mangohud
-	neovim
-	nfs-utils
-	ninja
-	nodejs
-	nomacs
-	openssl
-	nerdfonts
-	pavucontrol
-	picom
-	polkit_gnome
-	powershell
-	protonup-ng
-	python3Full
-	python.pkgs.pip
-	qemu
-	ripgrep
-	rofi
-	steam
-	steam-run
-	sxhkd
-	st
-	stdenv
-	synergy
-	swaycons
-	terminus-nerdfont
-	tldr
-	trash-cli
-	unzip
-	variety
-	virt-manager
-	xclip
-	xdg-desktop-portal-gtk
-	xfce.thunar
-	xorg.libX11
-	xorg.libX11.dev
-	xorg.libxcb
-	xorg.libXft
-	xorg.libXinerama
-	xorg.xinit
-  	xorg.xinput
-	(lutris.override {
-	       extraPkgs = pkgs: [
-		 # List package dependencies here
-		 wineWowPackages.stable
-		 winetricks
-	       ];
-	    })
+  environment.systemPackages = with pkgs; [
+    vim
+    wget
+    w3m
+    dmenu
+    neofetch
+    neovim
+    autojump
+    starship
+    floorp
+    bspwm
+    cargo
+    celluloid
+    chatterino2
+    clang-tools_9
+    davinci-resolve
+    dwm
+    dunst
+    elinks
+    eww
+    feh
+    flameshot
+    flatpak
+    fontconfig
+    freetype
+    gcc
+    gh
+    gimp
+    git
+    github-desktop
+    gnugrep
+    gnumake
+    gparted
+    hugo
+    kitty
+    libverto
+    luarocks
+    lutris
+    mangohud
+    neovim
+    nfs-utils
+    ninja
+    nodejs
+    nomacs
+    openssl
+    nerdfonts
+    pavucontrol
+    picom
+    polkit_gnome
+    powershell
+    protonup-ng
+    python3Full
+    python.pkgs.pip
+    qemu
+    ripgrep
+    rofi
+    steam
+    steam-run
+    sxhkd
+    st
+    stdenv
+    synergy
+    swaycons
+    terminus-nerdfont
+    tldr
+    trash-cli
+    unzip
+    variety
+    virt-manager
+    xclip
+    xdg-desktop-portal-gtk
+    xfce.thunar
+    xorg.libX11
+    xorg.libX11.dev
+    xorg.libxcb
+    xorg.libXft
+    xorg.libXinerama
+    xorg.xinit
+    xorg.xinput
+    (lutris.override {
+      extraPkgs = pkgs: [
+        # List package dependencies here
+        wineWowPackages.stable
+        winetricks
+      ];
+    })
   ];
 
   nixpkgs.overlays = [
-	(final: prev: {
-		dwm = prev.dwm.overrideAttrs (old: { src = /home/titus/GitHub/dwm-titus ;});
-	})
+    (final: prev: {
+      dwm = prev.dwm.overrideAttrs (old: { src = /home/titus/GitHub/dwm-titus ;});
+    })
   ];
 
   ## Gaming
-	programs.steam = {
-	  enable = true;
-	  remotePlay.openFirewall = true; # Open ports in the firewall for Steam Remote Play
-	  dedicatedServer.openFirewall = true; # Open ports in the firewall for Source Dedicated Server
-	};
+  programs.steam = {
+    enable = true;
+    remotePlay.openFirewall = true; # Open ports in the firewall for Steam Remote Play
+    dedicatedServer.openFirewall = true; # Open ports in the firewall for Source Dedicated Server
+  };
 
 
   # List services that you want to enable:
@@ -216,24 +215,24 @@ services.xserver.displayManager.setupCommands = ''
     extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
   };
   security.polkit.enable = true;
- systemd = {
-  user.services.polkit-gnome-authentication-agent-1 = {
-    description = "polkit-gnome-authentication-agent-1";
-    wantedBy = [ "graphical-session.target" ];
-    wants = [ "graphical-session.target" ];
-    after = [ "graphical-session.target" ];
-    serviceConfig = {
+  systemd = {
+    user.services.polkit-gnome-authentication-agent-1 = {
+      description = "polkit-gnome-authentication-agent-1";
+      wantedBy = [ "graphical-session.target" ];
+      wants = [ "graphical-session.target" ];
+      after = [ "graphical-session.target" ];
+      serviceConfig = {
         Type = "simple";
         ExecStart = "${pkgs.polkit_gnome}/libexec/polkit-gnome-authentication-agent-1";
         Restart = "on-failure";
         RestartSec = 1;
         TimeoutStopSec = 10;
       };
+    };
+    extraConfig = ''
+      DefaultTimeoutStopSec=10s
+    '';
   };
-   extraConfig = ''
-     DefaultTimeoutStopSec=10s
-   '';
-};
 
   # Open ports in the firewall.
   # networking.firewall.allowedTCPPorts = [ ... ];
@@ -242,7 +241,7 @@ services.xserver.displayManager.setupCommands = ''
   networking.firewall.enable = false;
   networking.enableIPv6 = false;
 
-fonts = {                                                  #This is depricated new sytax will
+  fonts = {                                                  #This is depricated new sytax will
     fonts = with pkgs; [                                   #be enforced in the next realease
       noto-fonts
       noto-fonts-cjk
@@ -256,12 +255,13 @@ fonts = {                                                  #This is depricated n
     fontconfig = {
       enable = true;
       defaultFonts = {
-	      monospace = [ "Meslo LG M Regular Nerd Font Complete Mono" ];
-	      serif = [ "Noto Serif" "Source Han Serif" ];
-	      sansSerif = [ "Noto Sans" "Source Han Sans" ];
+        monospace = [ "Meslo LG M Regular Nerd Font Complete Mono" ];
+        serif = [ "Noto Serif" "Source Han Serif" ];
+        sansSerif = [ "Noto Sans" "Source Han Sans" ];
       };
     };
-};
+  };
+
   # Copy the NixOS configuration file and link it from the resulting system
   # (/run/current-system/configuration.nix). This is useful in case you
   # accidentally delete configuration.nix.
@@ -277,5 +277,4 @@ fonts = {                                                  #This is depricated n
   # Before changing this value read the documentation for this option
   # (e.g. man configuration.nix or on https://nixos.org/nixos/options.html).
   system.stateVersion = "23.11"; # Did you read the comment?
-
 }

--- a/configuration.nix
+++ b/configuration.nix
@@ -102,28 +102,22 @@
   # List packages installed in system profile. To search, run:
   # $ nix search wget
   environment.systemPackages = with pkgs; [
-    vim
-    wget
-    w3m
-    dmenu
-    neofetch
-    neovim
     autojump
-    starship
-    floorp
     bspwm
     cargo
     celluloid
     chatterino2
     clang-tools_9
     davinci-resolve
-    dwm
+    dmenu
     dunst
+    dwm
     elinks
     eww
     feh
     flameshot
     flatpak
+    floorp
     fontconfig
     freetype
     gcc
@@ -140,13 +134,15 @@
     luarocks
     lutris
     mangohud
+    neofetch
     neovim
+    neovim
+    nerdfonts
     nfs-utils
     ninja
     nodejs
     nomacs
     openssl
-    nerdfonts
     pavucontrol
     picom
     polkit_gnome
@@ -157,11 +153,12 @@
     qemu
     ripgrep
     rofi
+    st
+    starship
+    stdenv
     steam
     steam-run
     sxhkd
-    st
-    stdenv
     synergy
     swaycons
     terminus-nerdfont
@@ -169,7 +166,10 @@
     trash-cli
     unzip
     variety
+    vim
     virt-manager
+    w3m
+    wget
     xclip
     xdg-desktop-portal-gtk
     xfce.thunar


### PR DESCRIPTION
## Quick description
The last PR changed the channel to nixos-24.05. That channel does not exist because NixOS 24.05 isn't out, yet. 
Also I reverted the system.stateVersion value back to 22.11 because you are not meant to change it ever. This defines what version you used to create the configuration file - not what version you are currently on. I also added a more clear warning.

And while I was at it, I removed all duplicates from the systemPackages, sorted the packages alphabetically and did a bit of cleanup (e.g. moving all services lines together) so the file is easier to work with.

## List of changes
* Made the formatting consistent. Everything is now how NixOS would generate it
* Sorted all packages in environment.systemPackages alphabetically
* Removed the duplicates in the systemPackages
* Did all fixes
* Changed fonts.fonts to the new syntax so you don't have to do it later
* services, networking etc. is now in one place, making the file easier to work with